### PR TITLE
Fix build: update secp256k1 hash and CI Zig version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.0
 
       - name: Create cache directory
         run: mkdir -p .zig-cache/global
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.0
 
       - name: Create cache directories (Unix)
         if: runner.os != 'Windows'
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.0
 
       - name: Create cache directories (Unix)
         if: runner.os != 'Windows'
@@ -134,7 +134,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.0
 
       - name: Create cache directory
         run: mkdir -p .zig-cache/global
@@ -160,7 +160,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.0
 
       - name: Create cache directory
         run: mkdir -p .zig-cache/global

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,7 +16,7 @@
     .dependencies = .{
         .zig_eth_secp256k1 = .{
             .url = "https://github.com/DaviRain-Su/zig-eth-secp256k1/archive/refs/heads/main.tar.gz",
-            .hash = "zig_eth_secp256k1-0.1.0-_U97sLbpDAATA_3x8cFERYszQ8DPzDck3ZiffzwQOcnt",
+            .hash = "zig_eth_secp256k1-0.1.0-_U97sBjqDACdmkjL_I_1dncMBvOZ0iSxbcMg4pIcVM4P",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Summary

Fixes two related build issues:

1. **Stale dependency hash**: The `zig-eth-secp256k1` dependency hash in `build.zig.zon` no longer matches the upstream `main` branch tarball. Updated to the current hash.

2. **CI Zig version mismatch**: CI was using Zig 0.14.1, but `build.zig.zon` declares `minimum_zig_version = "0.15.0"`. Updated all CI jobs to use Zig 0.15.0.

## Test plan

- [x] `zig build test -Doptimize=ReleaseSafe` passes locally (macOS ARM64)
- [ ] CI should pass on all platforms with Zig 0.15.0

Fixes #45